### PR TITLE
Fixes for fresh install of Fedora

### DIFF
--- a/install-openqa.sh
+++ b/install-openqa.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-# Test scrip based on installation guide from Fedora:
+# Test script based on installation guide from Fedora:
 # https://fedoraproject.org/wiki/OpenQA_direct_installation_guide
 export release=$(uname -a)
 echo Installing OpenQA on Fedora 

--- a/install-openqa.sh
+++ b/install-openqa.sh
@@ -40,7 +40,8 @@ sudo systemctl restart httpd
 
 echo Note! the api key will expire in one day after installation!
 
-sudo bash -c "cat >/etc/openqa/client.conf <<'EOF'[localhost]
+sudo bash -c "cat >/etc/openqa/client.conf <<'EOF'
+[localhost]
 key = 1234567890ABCDEF 
 secret = 1234567890ABCDEF 
 EOF"

--- a/install-openqa.sh
+++ b/install-openqa.sh
@@ -14,15 +14,15 @@ cd /etc/httpd/conf.d/
 sudo cp openqa.conf.template openqa.conf
 sudo cp openqa-ssl.conf.template openqa-ssl.conf
 
-sudo cat << EOF >  /etc/openqa/openqa.ini 
+sudo bash -c "cat >/etc/openqa/openqa.ini <<'EOF'
 [global]
 branding=plain
 download_domains = fedoraproject.org
 [auth]
 method = Fake
-EOF
+EOF"
 
-postgresql-setup --initdb
+sudo postgresql-setup --initdb
 
 sudo systemctl enable --now postgresql
 sudo systemctl enable --now httpd
@@ -40,11 +40,10 @@ sudo systemctl restart httpd
 
 echo Note! the api key will expire in one day after installation!
 
-sudo cat << EOF >  /etc/openqa/client.conf 
-[localhost]
+sudo bash -c "cat >/etc/openqa/client.conf <<'EOF'[localhost]
 key = 1234567890ABCDEF 
 secret = 1234567890ABCDEF 
-EOF
+EOF"
 
 echo "Done, preparations. Now log in one time! Then run sudo ./install-openqa-post.sh"
 


### PR DESCRIPTION
I just did a fresh install of Fedora server and ran into a few issues with this script. 
I fixed this error:
`./install-openqa.sh: line 17: /etc/openqa/openqa.ini: Permission denied`
 By wrapping the cat in a sudo bash. Same with 43.

I fixed this error:
`ERROR: The /var/lib/pgsql directory has wrong permissions.`
By adding sudo to the postgresql-setup